### PR TITLE
Do not add errors for non-default locale with default values when default locale is invalid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - ruby-version: 3.0.2
+          - ruby-version: 3.2.2
             gemfile: gemfiles/Gemfile.rails.7.0
-          - ruby-version: 2.7.4
+          - ruby-version: 3.1.4
+            gemfile: gemfiles/Gemfile.rails.7.0
+          - ruby-version: 3.0.6
+            gemfile: gemfiles/Gemfile.rails.7.0
+          - ruby-version: 2.7.8
             gemfile: gemfiles/Gemfile.rails.6.1
-          - ruby-version: 2.6.8
+          - ruby-version: 2.6.10
             gemfile: gemfiles/Gemfile.rails.6.0
           - ruby-version: 2.5.9
             gemfile: gemfiles/Gemfile.rails.5.2

--- a/test/globalize_validations_test.rb
+++ b/test/globalize_validations_test.rb
@@ -189,9 +189,23 @@ class GlobalizeValidationsTest < ActiveSupport::TestCase
 
   test "return errors for all locales when default locale is invalid and others are not provided but have valid default" do
     page = PageWithValidDefault.new(title_en: "titlex")
+
     assert page.invalid?
     assert_equal ["is too long (maximum is 5 characters)"], page.errors[:title_en]
     assert_empty page.errors[:title_es]
+    assert_empty page.errors[:title_fr]
+  end
+
+  test "return errors for all locales when default locale is invalid and others fall back to default" do
+    page = PageWithValidDefault.new(title_en: "titlex", title_fr: "title")
+
+    fallbacks = I18n.fallbacks
+    I18n.fallbacks = { en: [:en], fr: [:fr, :en], es: [:es, :en] }
+    assert page.invalid?
+    I18n.fallbacks = fallbacks
+
+    assert_equal ["is too long (maximum is 5 characters)"], page.errors[:title_en]
+    assert_equal ["is too long (maximum is 5 characters)"], page.errors[:title_es]
     assert_empty page.errors[:title_fr]
   end
 end

--- a/test/globalize_validations_test.rb
+++ b/test/globalize_validations_test.rb
@@ -103,9 +103,9 @@ class GlobalizeValidationsTest < ActiveSupport::TestCase
 
     assert page.invalid?, "Can't be valid with title present for all locales"
 
-    assert_equal ["can't be blank"],  page.errors[:title_en]
-    assert_equal ["can't be blank"],  page.errors[:title_fr]
-    assert_equal ["can't be blank"],  page.errors[:title_es]
+    assert_equal ["can't be blank"],  (page.errors[:title_en].map { |e| e.tr("’", "'") })
+    assert_equal ["can't be blank"],  (page.errors[:title_fr].map { |e| e.tr("’", "'") })
+    assert_equal ["can't be blank"],  (page.errors[:title_es].map { |e| e.tr("’", "'") })
   end
 
   test "does not keep errors in none translated attribute names" do
@@ -176,13 +176,13 @@ class GlobalizeValidationsTest < ActiveSupport::TestCase
   test "returns errors for composed locales" do
     page = PageWithComposedLocale.new(title_en: "Title")
     page.valid?
-    assert_equal ["can't be blank"], page.errors[:title_zh_tw]
+    assert_equal ["can't be blank"], (page.errors[:title_zh_tw].map { |e| e.tr("’", "'") })
   end
 
   test "returns only one error when only default locale is invalid and others are provided" do
     page = Page.new(title_fr: "title", title_es: "title")
     page.valid?
-    assert_equal ["can't be blank"], page.errors[:title_en]
+    assert_equal ["can't be blank"], (page.errors[:title_en].map { |e| e.tr("’", "'") })
     assert_empty page.errors[:title_es]
     assert_empty page.errors[:title_fr]
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,8 @@ require 'globalize-validations'
 
 test_dir = File.dirname(__FILE__)
 
+I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
+
 ActiveRecord::Base.logger = Logger.new(File.join(test_dir, "debug.log"))
 ActiveRecord::Base.establish_connection(
   adapter: "sqlite3",


### PR DESCRIPTION
Consider a situation when default locale (`I18n.locale`) for attribute `x` is provided with invalid value. No other locales are provided for that attribute. 
```
  obj = Object.new(x_en: "invalid")
```

With an app configuration that falls back to default translation, whenever no translation is available, it will return the invalid value.

```
  Globalize.locale # => :en
  obj.x_pl # => "invalid"
```

In that situation, running `obj.validate!` will return errors for all locales available for that object.
```
  obj.valid?
  errors.messages # => x_en is invalid, x_pl is invalid
```

This merge request allows to negate this issue and return the validation error only for the default locale if the returned value by that attribute can response do `translation_metadata`. With this information in hand it will make an informed decision to skip validation error when fallback is used.

This feature is part of I18n library and can be can be enabled by simply including the Metadata module into the Simple backend class - or whatever other backend is being used. Go to place for that line is initializer for i18n.

```
I18n::Backend::Simple.include(I18n::Backend::Metadata)
```